### PR TITLE
Fixed a issue and enhance the internval number count

### DIFF
--- a/sensu/handler.py
+++ b/sensu/handler.py
@@ -81,7 +81,7 @@ class Handler(object):
         if self.event.get('occurrences') > occurrences and \
             self.event.get('action') == 'create':
             number = int(float(refresh) / float(interval))
-            if self.event.get('occurrences') % number != 0:
+            if number != 0 and (self.event.get('occurrences') - occurrences) % number != 0:
                 self.bail('only handling every {0} occurrences'.format(
                     number))
                 return True


### PR DESCRIPTION
1, When the check refresh < internval, the number will be 0, and it will raise exception "ZeroDivisionError: integer division or modulo by zero". 
2, Should subtract the check.occurrences from the event's